### PR TITLE
Generate ethereum address with findOrCreateUser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install --save-dev -y mocha --prefix /usr/local/
 RUN npm install --save-dev -y sequelize --prefix /usr/local/
 RUN npm install --save-dev -y pg pg-hstore --prefix /usr/local/
 RUN npm install --save-dev -y dotenv --prefix /usr/local/
+RUN npm install --save-dev -y dotenv --prefix /usr/local/
+RUN npm install --save-dev -y ethereumjs-wallet --prefix /usr/local/
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN npm install --save-dev -y mocha --prefix /usr/local/
 RUN npm install --save-dev -y sequelize --prefix /usr/local/
 RUN npm install --save-dev -y pg pg-hstore --prefix /usr/local/
 RUN npm install --save-dev -y dotenv --prefix /usr/local/
-RUN npm install --save-dev -y dotenv --prefix /usr/local/
 RUN npm install --save-dev -y ethereumjs-wallet --prefix /usr/local/
 
 COPY . .

--- a/lib/createUser.js
+++ b/lib/createUser.js
@@ -16,14 +16,21 @@ async function createUser(
     contributor_signature = EthWallet.getPrivateKeyString()
   }
   try {
+   const contributor = await Contributor.findOne({where:{contributor_name: contributor_name}})
+    if(contributor){
+    console.log('user already exists:', contributor_name)
+    return 403
+    }
     await Contributor.create({
       contributor_id: contributor_id,
       contributor_name: contributor_name,
       contributor_signature: contributor_signature,
       token: token,
     });
+    console.log('user created', contributor_id, contributor_name, contributor_signature, token);
     return 201;
   } catch (error) {
+    console.log('error', error);
     return `There was an error: ${error}`;
   }
 }

--- a/lib/createUser.js
+++ b/lib/createUser.js
@@ -1,4 +1,6 @@
 const { Contributor } = require("../server/db");
+const Wallet = require('ethereumjs-wallet');
+
 
 async function createUser(
   /*owner:*/ owner,
@@ -8,6 +10,11 @@ async function createUser(
   /*contributor_signature:*/ contributor_signature,
   /*token:*/ token
 ) {
+  if(contributor_id === 'none' || contributor_signature === 'none'){
+    const EthWallet = Wallet.default.generate();
+    contributor_id = EthWallet.getAddressString()
+    contributor_signature = EthWallet.getPrivateKeyString()
+  }
   try {
     await Contributor.create({
       contributor_id: contributor_id,

--- a/lib/createUser.js
+++ b/lib/createUser.js
@@ -16,19 +16,15 @@ async function createUser(
     contributor_signature = EthWallet.getPrivateKeyString()
   }
   try {
-   const contributor = await Contributor.findOne({where:{contributor_name: contributor_name}})
-    if(contributor){
-    console.log('user already exists:', contributor_name)
-    return 403
-    }
-    await Contributor.create({
+    const [contributor, created]= await Contributor.findOrCreate({
+      where: {contributor_name:contributor_name},
+      defaults: {
       contributor_id: contributor_id,
       contributor_name: contributor_name,
       contributor_signature: contributor_signature,
       token: token,
-    });
-    console.log('user created', contributor_id, contributor_name, contributor_signature, token);
-    return 201;
+    }});
+    return {contributor_id: contributor.contributor_id, contributor_signature: contributor.contributor_signature, token:contributor.token, contributor_name: contributor.contributor_name};
   } catch (error) {
     console.log('error', error);
     return `There was an error: ${error}`;

--- a/lib/createUser.js
+++ b/lib/createUser.js
@@ -1,6 +1,4 @@
 const { Contributor } = require("../server/db");
-const Wallet = require('ethereumjs-wallet');
-
 
 async function createUser(
   /*owner:*/ owner,
@@ -10,21 +8,14 @@ async function createUser(
   /*contributor_signature:*/ contributor_signature,
   /*token:*/ token
 ) {
-  if(contributor_id === 'none' || contributor_signature === 'none'){
-    const EthWallet = Wallet.default.generate();
-    contributor_id = EthWallet.getAddressString()
-    contributor_signature = EthWallet.getPrivateKeyString()
-  }
   try {
-    const [contributor, created]= await Contributor.findOrCreate({
-      where: {contributor_name:contributor_name},
-      defaults: {
+    await Contributor.create({
       contributor_id: contributor_id,
       contributor_name: contributor_name,
       contributor_signature: contributor_signature,
       token: token,
-    }});
-    return {contributor_id: contributor.contributor_id, contributor_signature: contributor.contributor_signature, token:contributor.token, contributor_name: contributor.contributor_name};
+    });
+    return 201;
   } catch (error) {
     console.log('error', error);
     return `There was an error: ${error}`;

--- a/lib/findOrCreateUser.js
+++ b/lib/findOrCreateUser.js
@@ -1,7 +1,6 @@
 const { Contributor } = require("../server/db");
 const Wallet = require('ethereumjs-wallet');
 
-
 async function findOrCreateUser(
   /*owner:*/ owner,
   /*repo:*/ repo,
@@ -24,12 +23,14 @@ async function findOrCreateUser(
       contributor_signature: contributor_signature,
       token: token,
     }});
-    return {
-        contributor_name: contributor.contributor_name,
-        contributor_id: contributor.contributor_id,
-        contributor_signature: contributor.contributor_signature,
-        token: contributor.token,
-      };
+    const response = {
+      contributor_name: contributor.contributor_name,
+      contributor_id: contributor.contributor_id,
+      contributor_signature: contributor.contributor_signature,
+      token: contributor.token,
+    };
+    console.log('response', response)
+    return response;
   } catch (error) {
     console.log('error', error);
     return `There was an error: ${error}`;

--- a/lib/findOrCreateUser.js
+++ b/lib/findOrCreateUser.js
@@ -1,0 +1,38 @@
+const { Contributor } = require("../server/db");
+const Wallet = require('ethereumjs-wallet');
+
+
+async function findOrCreateUser(
+  /*owner:*/ owner,
+  /*repo:*/ repo,
+  /*contributor_id:*/ contributor_id,
+  /*contributor_name:*/ contributor_name,
+  /*contributor_signature:*/ contributor_signature,
+  /*token:*/ token
+) {
+  if(contributor_id === 'none' || contributor_signature === 'none'){
+    const EthWallet = Wallet.default.generate();
+    contributor_id = EthWallet.getAddressString()
+    contributor_signature = EthWallet.getPrivateKeyString()
+  }
+  try {
+    const [contributor, created] = await Contributor.findOrCreate({
+      where: {contributor_name: contributor_name },
+      defaults: {
+      contributor_id: contributor_id,
+      contributor_name: contributor_name,
+      contributor_signature: contributor_signature,
+      token: token,
+    }});
+    return {
+        contributor_name: contributor.contributor_name,
+        contributor_id: contributor.contributor_id,
+        contributor_signature: contributor.contributor_signature,
+        token: contributor.token,
+      };
+  } catch (error) {
+    console.log('error', error);
+    return `There was an error: ${error}`;
+  }
+}
+module.exports = findOrCreateUser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const getContributorID = require("./getContributorID");
 const getContributorSignature = require("./getContributorSignature");
 const getContributorName = require("./getContributorName");
 const getUser = require("./getUser");
+const findOrCreateUser = require("./findOrCreateUser");
 
 module.exports = {
   createUser,
@@ -10,4 +11,5 @@ module.exports = {
   getContributorName,
   getContributorSignature,
   getUser,
+  findOrCreateUser,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
          "version": "0.0.1",
          "license": "MIT",
          "dependencies": {
+            "ethereumjs-wallet": "^1.0.2",
             "express": "^4.17.1",
             "express-graphql": "^0.12.0",
-            "graphql": "^16.0.1",
+            "graphql": "^15.3.0",
             "mocha": "^9.2.0",
             "pg": "^8.7.3",
             "pg-hstore": "^2.3.4",
@@ -20,6 +21,14 @@
          },
          "devDependencies": {
             "dotenv": "^16.0.1"
+         }
+      },
+      "node_modules/@types/bn.js": {
+         "version": "5.1.1",
+         "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+         "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+         "dependencies": {
+            "@types/node": "*"
          }
       },
       "node_modules/@types/debug": {
@@ -39,6 +48,22 @@
          "version": "18.6.2",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
          "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      },
+      "node_modules/@types/pbkdf2": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+         "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+         "dependencies": {
+            "@types/node": "*"
+         }
+      },
+      "node_modules/@types/secp256k1": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+         "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+         "dependencies": {
+            "@types/node": "*"
+         }
       },
       "node_modules/@types/validator": {
          "version": "13.7.4",
@@ -61,6 +86,11 @@
          "engines": {
             "node": ">= 0.6"
          }
+      },
+      "node_modules/aes-js": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+         "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
       },
       "node_modules/ansi-colors": {
          "version": "4.1.1",
@@ -129,6 +159,14 @@
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
       },
+      "node_modules/base-x": {
+         "version": "3.0.9",
+         "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+         "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+         "dependencies": {
+            "safe-buffer": "^5.0.1"
+         }
+      },
       "node_modules/binary-extensions": {
          "version": "2.2.0",
          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -136,6 +174,16 @@
          "engines": {
             "node": ">=8"
          }
+      },
+      "node_modules/blakejs": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+         "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      },
+      "node_modules/bn.js": {
+         "version": "5.2.1",
+         "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+         "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
       },
       "node_modules/body-parser": {
          "version": "1.20.0",
@@ -180,10 +228,46 @@
             "node": ">=8"
          }
       },
+      "node_modules/brorand": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+         "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      },
       "node_modules/browser-stdout": {
          "version": "1.3.1",
          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      },
+      "node_modules/browserify-aes": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+         "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+         "dependencies": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "node_modules/bs58": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+         "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+         "dependencies": {
+            "base-x": "^3.0.2"
+         }
+      },
+      "node_modules/bs58check": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+         "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+         "dependencies": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+         }
       },
       "node_modules/buffer-writer": {
          "version": "2.0.0",
@@ -192,6 +276,11 @@
          "engines": {
             "node": ">=4"
          }
+      },
+      "node_modules/buffer-xor": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+         "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
       },
       "node_modules/bytes": {
          "version": "3.1.2",
@@ -274,6 +363,15 @@
          },
          "optionalDependencies": {
             "fsevents": "~2.3.2"
+         }
+      },
+      "node_modules/cipher-base": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+         "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+         "dependencies": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
          }
       },
       "node_modules/cliui": {
@@ -360,6 +458,31 @@
          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
          "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
       },
+      "node_modules/create-hash": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+         "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+         "dependencies": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+         }
+      },
+      "node_modules/create-hmac": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+         "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+         "dependencies": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+         }
+      },
       "node_modules/debug": {
          "version": "2.6.9",
          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -440,6 +563,25 @@
          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
          "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
       },
+      "node_modules/elliptic": {
+         "version": "6.5.4",
+         "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+         "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+         "dependencies": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+         }
+      },
+      "node_modules/elliptic/node_modules/bn.js": {
+         "version": "4.12.0",
+         "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+         "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      },
       "node_modules/emoji-regex": {
          "version": "8.0.0",
          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -483,6 +625,67 @@
          "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
          "engines": {
             "node": ">= 0.6"
+         }
+      },
+      "node_modules/ethereum-cryptography": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+         "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+         "dependencies": {
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
+         }
+      },
+      "node_modules/ethereumjs-util": {
+         "version": "7.1.5",
+         "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+         "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+         "dependencies": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+         },
+         "engines": {
+            "node": ">=10.0.0"
+         }
+      },
+      "node_modules/ethereumjs-wallet": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
+         "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
+         "dependencies": {
+            "aes-js": "^3.1.2",
+            "bs58check": "^2.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethereumjs-util": "^7.1.2",
+            "randombytes": "^2.1.0",
+            "scrypt-js": "^3.0.1",
+            "utf8": "^3.0.0",
+            "uuid": "^8.3.2"
+         }
+      },
+      "node_modules/evp_bytestokey": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+         "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+         "dependencies": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
          }
       },
       "node_modules/express": {
@@ -778,11 +981,11 @@
          }
       },
       "node_modules/graphql": {
-         "version": "16.5.0",
-         "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-         "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+         "version": "15.3.0",
+         "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+         "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
          "engines": {
-            "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            "node": ">= 10.x"
          }
       },
       "node_modules/growl": {
@@ -823,6 +1026,28 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/hash-base": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+         "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+         "dependencies": {
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+         },
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/hash.js": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+         "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+         "dependencies": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+         }
+      },
       "node_modules/he": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -837,6 +1062,16 @@
          "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/hmac-drbg": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+         "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+         "dependencies": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
          }
       },
       "node_modules/http-errors": {
@@ -976,6 +1211,20 @@
             "js-yaml": "bin/js-yaml.js"
          }
       },
+      "node_modules/keccak": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
+         "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+         "hasInstallScript": true,
+         "dependencies": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0",
+            "readable-stream": "^3.6.0"
+         },
+         "engines": {
+            "node": ">=10.0.0"
+         }
+      },
       "node_modules/locate-path": {
          "version": "6.0.0",
          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1019,6 +1268,16 @@
          },
          "engines": {
             "node": ">=10"
+         }
+      },
+      "node_modules/md5.js": {
+         "version": "1.3.5",
+         "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+         "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+         "dependencies": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
          }
       },
       "node_modules/media-typer": {
@@ -1071,6 +1330,16 @@
          "engines": {
             "node": ">= 0.6"
          }
+      },
+      "node_modules/minimalistic-assert": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+         "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      },
+      "node_modules/minimalistic-crypto-utils": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+         "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
       },
       "node_modules/minimatch": {
          "version": "4.2.1",
@@ -1194,6 +1463,21 @@
             "node": ">= 0.6"
          }
       },
+      "node_modules/node-addon-api": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+         "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      },
+      "node_modules/node-gyp-build": {
+         "version": "4.6.0",
+         "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+         "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+         "bin": {
+            "node-gyp-build": "bin.js",
+            "node-gyp-build-optional": "optional.js",
+            "node-gyp-build-test": "build-test.js"
+         }
+      },
       "node_modules/normalize-path": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1290,6 +1574,21 @@
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      },
+      "node_modules/pbkdf2": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+         "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+         "dependencies": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+         },
+         "engines": {
+            "node": ">=0.12"
+         }
       },
       "node_modules/pg": {
          "version": "8.7.3",
@@ -1515,6 +1814,26 @@
          "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
          "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
       },
+      "node_modules/ripemd160": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+         "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+         "dependencies": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+         }
+      },
+      "node_modules/rlp": {
+         "version": "2.2.7",
+         "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+         "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+         "dependencies": {
+            "bn.js": "^5.2.0"
+         },
+         "bin": {
+            "rlp": "bin/rlp"
+         }
+      },
       "node_modules/safe-buffer": {
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1538,6 +1857,25 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      },
+      "node_modules/scrypt-js": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+         "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      },
+      "node_modules/secp256k1": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+         "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+         "hasInstallScript": true,
+         "dependencies": {
+            "elliptic": "^6.5.4",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+         },
+         "engines": {
+            "node": ">=10.0.0"
+         }
       },
       "node_modules/semver": {
          "version": "7.3.7",
@@ -1690,10 +2028,27 @@
             "node": ">= 0.8.0"
          }
       },
+      "node_modules/setimmediate": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+         "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      },
       "node_modules/setprototypeof": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      },
+      "node_modules/sha.js": {
+         "version": "2.4.11",
+         "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+         "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+         "dependencies": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+         },
+         "bin": {
+            "sha.js": "bin.js"
+         }
       },
       "node_modules/side-channel": {
          "version": "1.0.4",
@@ -1883,6 +2238,11 @@
             "node": ">= 0.8"
          }
       },
+      "node_modules/utf8": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+         "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+      },
       "node_modules/util-deprecate": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2041,6 +2401,14 @@
       }
    },
    "dependencies": {
+      "@types/bn.js": {
+         "version": "5.1.1",
+         "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+         "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+         "requires": {
+            "@types/node": "*"
+         }
+      },
       "@types/debug": {
          "version": "4.1.7",
          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -2058,6 +2426,22 @@
          "version": "18.6.2",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
          "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      },
+      "@types/pbkdf2": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+         "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+         "requires": {
+            "@types/node": "*"
+         }
+      },
+      "@types/secp256k1": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+         "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+         "requires": {
+            "@types/node": "*"
+         }
       },
       "@types/validator": {
          "version": "13.7.4",
@@ -2077,6 +2461,11 @@
             "mime-types": "~2.1.34",
             "negotiator": "0.6.3"
          }
+      },
+      "aes-js": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+         "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
       },
       "ansi-colors": {
          "version": "4.1.1",
@@ -2130,10 +2519,28 @@
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
       },
+      "base-x": {
+         "version": "3.0.9",
+         "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+         "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+         "requires": {
+            "safe-buffer": "^5.0.1"
+         }
+      },
       "binary-extensions": {
          "version": "2.2.0",
          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      },
+      "blakejs": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+         "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      },
+      "bn.js": {
+         "version": "5.2.1",
+         "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+         "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
       },
       "body-parser": {
          "version": "1.20.0",
@@ -2171,15 +2578,56 @@
             "fill-range": "^7.0.1"
          }
       },
+      "brorand": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+         "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      },
       "browser-stdout": {
          "version": "1.3.1",
          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
       },
+      "browserify-aes": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+         "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+         "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "bs58": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+         "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+         "requires": {
+            "base-x": "^3.0.2"
+         }
+      },
+      "bs58check": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+         "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+         "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+         }
+      },
       "buffer-writer": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
          "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+      },
+      "buffer-xor": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+         "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
       },
       "bytes": {
          "version": "3.1.2",
@@ -2232,6 +2680,15 @@
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
             "readdirp": "~3.6.0"
+         }
+      },
+      "cipher-base": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+         "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+         "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
          }
       },
       "cliui": {
@@ -2303,6 +2760,31 @@
          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
          "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
       },
+      "create-hash": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+         "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+         "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+         }
+      },
+      "create-hmac": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+         "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+         "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+         }
+      },
       "debug": {
          "version": "2.6.9",
          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2361,6 +2843,27 @@
          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
          "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
       },
+      "elliptic": {
+         "version": "6.5.4",
+         "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+         "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+         "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+         },
+         "dependencies": {
+            "bn.js": {
+               "version": "4.12.0",
+               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+               "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+         }
+      },
       "emoji-regex": {
          "version": "8.0.0",
          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2390,6 +2893,64 @@
          "version": "1.8.1",
          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
          "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+      },
+      "ethereum-cryptography": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+         "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+         "requires": {
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
+         }
+      },
+      "ethereumjs-util": {
+         "version": "7.1.5",
+         "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+         "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+         "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+         }
+      },
+      "ethereumjs-wallet": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
+         "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
+         "requires": {
+            "aes-js": "^3.1.2",
+            "bs58check": "^2.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethereumjs-util": "^7.1.2",
+            "randombytes": "^2.1.0",
+            "scrypt-js": "^3.0.1",
+            "utf8": "^3.0.0",
+            "uuid": "^8.3.2"
+         }
+      },
+      "evp_bytestokey": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+         "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+         "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+         }
       },
       "express": {
          "version": "4.18.1",
@@ -2611,9 +3172,9 @@
          }
       },
       "graphql": {
-         "version": "16.5.0",
-         "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-         "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA=="
+         "version": "15.3.0",
+         "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+         "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
       },
       "growl": {
          "version": "1.10.5",
@@ -2638,6 +3199,25 @@
          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
       },
+      "hash-base": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+         "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+         "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+         }
+      },
+      "hash.js": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+         "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+         "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+         }
+      },
       "he": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -2647,6 +3227,16 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
          "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
+      },
+      "hmac-drbg": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+         "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+         "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+         }
       },
       "http-errors": {
          "version": "2.0.0",
@@ -2746,6 +3336,16 @@
             "argparse": "^2.0.1"
          }
       },
+      "keccak": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
+         "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+         "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0",
+            "readable-stream": "^3.6.0"
+         }
+      },
       "locate-path": {
          "version": "6.0.0",
          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2774,6 +3374,16 @@
          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
          "requires": {
             "yallist": "^4.0.0"
+         }
+      },
+      "md5.js": {
+         "version": "1.3.5",
+         "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+         "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+         "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
          }
       },
       "media-typer": {
@@ -2808,6 +3418,16 @@
          "requires": {
             "mime-db": "1.52.0"
          }
+      },
+      "minimalistic-assert": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+         "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      },
+      "minimalistic-crypto-utils": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+         "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
       },
       "minimatch": {
          "version": "4.2.1",
@@ -2898,6 +3518,16 @@
          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
          "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
       },
+      "node-addon-api": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+         "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      },
+      "node-gyp-build": {
+         "version": "4.6.0",
+         "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+         "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+      },
       "normalize-path": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2964,6 +3594,18 @@
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      },
+      "pbkdf2": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+         "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+         "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+         }
       },
       "pg": {
          "version": "8.7.3",
@@ -3125,6 +3767,23 @@
          "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
          "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
       },
+      "ripemd160": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+         "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+         "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+         }
+      },
+      "rlp": {
+         "version": "2.2.7",
+         "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+         "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+         "requires": {
+            "bn.js": "^5.2.0"
+         }
+      },
       "safe-buffer": {
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3134,6 +3793,21 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      },
+      "scrypt-js": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+         "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      },
+      "secp256k1": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+         "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+         "requires": {
+            "elliptic": "^6.5.4",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+         }
       },
       "semver": {
          "version": "7.3.7",
@@ -3232,10 +3906,24 @@
             "send": "0.18.0"
          }
       },
+      "setimmediate": {
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+         "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      },
       "setprototypeof": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      },
+      "sha.js": {
+         "version": "2.4.11",
+         "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+         "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+         "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+         }
       },
       "side-channel": {
          "version": "1.0.4",
@@ -3370,6 +4058,11 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
          "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+      },
+      "utf8": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+         "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
       },
       "util-deprecate": {
          "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
       "test": "/usr/local/node_modules/mocha/bin/mocha.js"
    },
    "dependencies": {
+      "ethereumjs-wallet": "^1.0.2",
       "express": "^4.17.1",
       "express-graphql": "^0.12.0",
-      "graphql": "^16.0.1",
+      "graphql": "^15.3.0",
       "mocha": "^9.2.0",
       "pg": "^8.7.3",
       "pg-hstore": "^2.3.4",

--- a/server/db/Models/Contributor.js
+++ b/server/db/Models/Contributor.js
@@ -4,15 +4,15 @@ const db = require("../db");
 const Contributor = db.define("contributor", {
   contributor_name: {
     type: Sequelize.STRING(),
-    isUnique: true,
+    unique: true,
   },
   contributor_id: {
     type: Sequelize.STRING(),
-    isUnique: true,
+    unique: true,
   },
   contributor_signature: {
     type: Sequelize.STRING(),
-    isUnique: true,
+    unique: true,
   },
   token: {
     type: Sequelize.STRING(),

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ const {
   getContributorSignature,
   getContributorName,
   getUser,
+  findOrCreateUser,
 } = require("../lib");
 
 var schema = buildSchema(`
@@ -25,6 +26,7 @@ type User {
     getContributorID(owner: String, repo: String, defaultHash: String, contributor_name: String): String,
     getContributorSignature(owner: String, repo: String, defaultHash: String, contributor_id: String): String,
     getUser(contributor_id: String): User,
+    findOrCreateUser(owner: String, repo: String, contributor_id: String, contributor_name: String, contributor_signature: String, token: String): User,
   }
 `);
 
@@ -69,6 +71,17 @@ var root = {
   },
   getUser: async (args) => {
     const res = await getUser(args.contributor_id);
+    return res;
+  },
+  findOrCreateUser: async (args) => {
+    const res = await findOrCreateUser(
+      args.owner,
+      args.repo,
+      args.contributor_id,
+      args.contributor_name,
+      args.contributor_signature,
+      args.token
+    );
     return res;
   },
 };

--- a/src/requests.js
+++ b/src/requests.js
@@ -73,6 +73,22 @@ var root = {
     const json = JSON.parse(res.text);
     return json.data.getUser;
   },
+  findOrCreateUser: async (
+    owner,
+    repo,
+    contributor_id,
+    contributor_name,
+    contributor_signature,
+    token) => {
+    const res = await superagent
+      .post(`${port}/graphql`)
+      .send({
+        query: `{ findOrCreateUser(owner: "${owner}", repo: "${repo}", contributor_id: "${contributor_id}", contributor_name: "${contributor_name}", contributor_signature: "${contributor_signature}", token: "${token}") {contributor_name, contributor_id, contributor_signature, token}}`,
+      })
+      .set("accept", "json");
+    const json = JSON.parse(res.text);
+    return json.data.findOrCreateUser;
+  },
 };
 
 module.exports = root;

--- a/test-server/findOrCreateUser.js
+++ b/test-server/findOrCreateUser.js
@@ -1,0 +1,35 @@
+const assert = require("assert");
+const { findOrCreateUser } = require("../src/requests");
+
+describe("findOrCreateUser", function () {
+  it("should find or create a new contributor in the database", async function () {
+    const mary = await findOrCreateUser(
+      /*owner:*/ "",
+      /*repo:*/ "",
+      /*contributor_id:*/ "0x0cc59907e45614540dAa22Cf62520306439360f2",
+      /*contributor_name:*/ "mary",
+      /*contributor_signature:*/ "fbd2479a0a10ce2fe8649c413913648271749d9cc61f4d5c7c7b11606b2bb1da",
+      /*token:*/ "ghp_1",
+    );
+    const joseph = await findOrCreateUser(
+      /*owner:*/ "",
+      /*repo:*/ "",
+      /*contributor_id:*/ "0x0c0DDaD894E3436C34AecD5722F0798Da88Bc971",
+      /*contributor_name:*/ "joseph",
+      /*contributor_signature:*/ "c823edc882af63fe6ea40e47a96974c89b14b84563ee73039c84690a15260aa9",
+      /*token:*/ "ghp_2",
+    );
+    const jericho = await findOrCreateUser(
+      /*owner:*/ "",
+      /*repo:*/ "",
+      /*contributor_id:*/ "none",
+      /*contributor_name:*/ "jericho",
+      /*contributor_signature:*/ "none",
+      /*token:*/ "ghp_123",
+    );
+        console.log(mary, joseph, jericho)
+    assert.equal(mary.contributor_id, "0x0cc59907e45614540dAa22Cf62520306439360f2", "Failed to find or create a user");
+    assert.equal(joseph.contributor_id, "0x0c0DDaD894E3436C34AecD5722F0798Da88Bc971", "Failed to find or create a user");
+    assert.equal(jericho.contributor_name, 'jericho', "Failed to find or create a user");
+  });
+});

--- a/test-server/postCreateUser.js
+++ b/test-server/postCreateUser.js
@@ -83,6 +83,14 @@ describe("postCreateUser", function () {
       /*contributor_signature:*/ "ec9a715c2ac1e570cc214b5f8d23bd7102affb5372dfcabd8ecd206c907e03f2",
       /*token:*/ "ghp_10",
     );
+    const samson = await postCreateUser(
+      /*owner:*/ "",
+      /*repo:*/ "",
+      /*contributor_id:*/ "none",
+      /*contributor_name:*/ "samson",
+      /*contributor_signature:*/ "none",
+      /*token:*/ "ghp_11",
+    );
     assert.equal(mary, 201, "Failed to create a user");
     assert.equal(joseph, 201, "Failed to create a user");
     assert.equal(gabriel, 201, "Failed to create a user");
@@ -93,5 +101,6 @@ describe("postCreateUser", function () {
     assert.equal(louis, 201, "Failed to create a user");
     assert.equal(thibaut, 201, "Failed to create a user");
     assert.equal(ignacius, 201, "Failed to create a user");
+    assert.equal(samson, 201, "Failed to create a user");
   });
 });

--- a/test-server/postCreateUser.js
+++ b/test-server/postCreateUser.js
@@ -83,14 +83,6 @@ describe("postCreateUser", function () {
       /*contributor_signature:*/ "ec9a715c2ac1e570cc214b5f8d23bd7102affb5372dfcabd8ecd206c907e03f2",
       /*token:*/ "ghp_10",
     );
-    const samson = await postCreateUser(
-      /*owner:*/ "",
-      /*repo:*/ "",
-      /*contributor_id:*/ "none",
-      /*contributor_name:*/ "samson",
-      /*contributor_signature:*/ "none",
-      /*token:*/ "ghp_11",
-    );
     assert.equal(mary, 201, "Failed to create a user");
     assert.equal(joseph, 201, "Failed to create a user");
     assert.equal(gabriel, 201, "Failed to create a user");
@@ -101,6 +93,5 @@ describe("postCreateUser", function () {
     assert.equal(louis, 201, "Failed to create a user");
     assert.equal(thibaut, 201, "Failed to create a user");
     assert.equal(ignacius, 201, "Failed to create a user");
-    assert.equal(samson, 201, "Failed to create a user");
   });
 });

--- a/test-server/run-tests.sh
+++ b/test-server/run-tests.sh
@@ -1,1 +1,1 @@
-npm test test-server/postCreateUser.js test-server/postGetContributorID.js test-server/postGetContributorSignature.js test-server/postgetContributorName.js test-server/getUser.js
+npm test test-server/postCreateUser.js test-server/postGetContributorID.js test-server/postGetContributorSignature.js test-server/postGetContributorName.js test-server/getUser.js test-server/findOrCreateUser.js


### PR DESCRIPTION
When findOrCreateUser is called with 'none' supplied as an argument for contributor id and contributor signature, an ethereum address and private key are generated automatically for the user.

NB - A dependency conflict of express graphql and graphql needed to be resolved before using the ethereum generator npm package. This was done by downgrading the version of graphql